### PR TITLE
Improve the documentation on the lintian section

### DIFF
--- a/getting_started/manual/index.html
+++ b/getting_started/manual/index.html
@@ -361,9 +361,10 @@ mkdir -p report
   <p>and add <code>lintian.txt</code> (no it's not a typo) to the list of
   artifacts to archive.</p>
 
-  <p>Enable the '<i>Publish JUnit test result report</i>' Post-build action and
-  select <code>**/lintian.xml</code> for the files to report.Then you should get
-  test reports for your Debian packages based on lintian's output.</p>
+  <p>Enable the '<i>Publish XUnit test result report</i>' Post-build action,
+  select JUnit in the list and select <code>**/lintian.xml</code> for the files
+  to report.Then you should get test reports for your Debian packages based on
+  lintian's output.</p>
 
 
   <section id="building">


### PR DESCRIPTION
unit is used as plugin and not Junit directly. Here is a
 further step which was missing
